### PR TITLE
Add CSV with projects with codes, add __pycache__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sqlite3*
 *.css
 *.css.map
+*__pycache__*

--- a/projects_with_codes_of_conduct.csv
+++ b/projects_with_codes_of_conduct.csv
@@ -1,0 +1,45 @@
+Project Name, Code of Conduct
+24 Pull Requests,https://github.com/24pullrequests/24pullrequests
+AASM,https://github.com/aasm/aasm
+Algorrent,https://github.com/algorrent/algorrent
+All HaskellNow.org Projects,http://www.haskellnow.org/wiki/WikiStart#Projects
+AngularJS,https://github.com/angular/code-of-conduct
+Bundler,https://github.com/bundler/bundler
+chef-rvm,https://github.com/fnichol/chef-rvm
+CloudI,http://cloudi.org/faq.html#2_CodeOfConduct
+CocoaPods,https://github.com/cocoapods/cocoapods
+Crackle,https://github.com/jordanekay/Crackle
+Eldest Daughter Questionnaire,https://github.com/eldest-daughter/ed-questionnaire
+Exercism.io,https://github.com/exercism/exercism.io
+Fukuzatsu,https://gitlab.com/coraline/fukuzatsu/tree/master
+GitLab,https://github.com/gitlabhq/gitlabhq
+Growing Devs,https://github.com/growingdevs/growingdevs.github.io
+Hacken.in,https://github.com/hacken-in/website
+Haskell Fill in the Blanks,https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/tree/master
+haxe-pixi,https://github.com/adireddy/haxe-pixi
+HealingRa.in Projects,https://gitlab.com/groups/healing-rain
+Homebrew-Cask,https://github.com/caskroom/homebrew-cask
+HTTPotion,https://github.com/myfreeweb/httpotion
+Lotus,http://lotusrb.org/community#code-of-conduct
+Mensa,https://github.com/jordanekay/Mensa
+Monsti CMS,http://www.monsti.org/
+Mozilla Webmaker,https://www.webmaker.org/
+NColony,https://github.com/moshez/ncolony
+OAPI ShieldsUp,https://github.com/oapi/shieldsup
+OpenDroneMap,https://github.com/OpenDroneMap/OpenDroneMap
+OpenProject,https://www.openproject.org/
+Ornament,https://github.com/jordanekay/Ornament
+Panamax,https://github.com/CenturyLinkLabs/panamax-ui
+Paramore,https://github.com/iancooper/Paramore
+Playscii,http://vectorpoem.com/playscii
+pmap,https://github.com/bruceadams/pmap
+PyBBIO,https://github.com/graycatlabs/PyBBIO
+ROM,https://github.com/rom-rb/rom
+ruby-community,https://github.com/apeiros/ruby-community
+RVM,https://github.com/rvm/rvm
+Snuffle,https://gitlab.com/coraline/snuffle/tree/master
+Snipe-IT,https://github.com/snipe/snipe-it
+vim cheat sheet,https://github.com/rtorr/vim-cheat-sheet
+Volt.rb,https://github.com/voltrb/volt
+WAI-request-spec,https://gitlab.com/cpp.cabrera/wai-request-spec
+xoreos,https://github.com/xoreos/xoreos

--- a/projects_with_codes_of_conduct.csv
+++ b/projects_with_codes_of_conduct.csv
@@ -1,45 +1,45 @@
-Project Name, Code of Conduct
-24 Pull Requests,https://github.com/24pullrequests/24pullrequests
-AASM,https://github.com/aasm/aasm
-Algorrent,https://github.com/algorrent/algorrent
-All HaskellNow.org Projects,http://www.haskellnow.org/wiki/WikiStart#Projects
-AngularJS,https://github.com/angular/code-of-conduct
-Bundler,https://github.com/bundler/bundler
-chef-rvm,https://github.com/fnichol/chef-rvm
-CloudI,http://cloudi.org/faq.html#2_CodeOfConduct
-CocoaPods,https://github.com/cocoapods/cocoapods
-Crackle,https://github.com/jordanekay/Crackle
-Eldest Daughter Questionnaire,https://github.com/eldest-daughter/ed-questionnaire
-Exercism.io,https://github.com/exercism/exercism.io
-Fukuzatsu,https://gitlab.com/coraline/fukuzatsu/tree/master
-GitLab,https://github.com/gitlabhq/gitlabhq
-Growing Devs,https://github.com/growingdevs/growingdevs.github.io
-Hacken.in,https://github.com/hacken-in/website
-Haskell Fill in the Blanks,https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/tree/master
-haxe-pixi,https://github.com/adireddy/haxe-pixi
-HealingRa.in Projects,https://gitlab.com/groups/healing-rain
-Homebrew-Cask,https://github.com/caskroom/homebrew-cask
-HTTPotion,https://github.com/myfreeweb/httpotion
-Lotus,http://lotusrb.org/community#code-of-conduct
-Mensa,https://github.com/jordanekay/Mensa
-Monsti CMS,http://www.monsti.org/
-Mozilla Webmaker,https://www.webmaker.org/
-NColony,https://github.com/moshez/ncolony
-OAPI ShieldsUp,https://github.com/oapi/shieldsup
-OpenDroneMap,https://github.com/OpenDroneMap/OpenDroneMap
-OpenProject,https://www.openproject.org/
-Ornament,https://github.com/jordanekay/Ornament
-Panamax,https://github.com/CenturyLinkLabs/panamax-ui
-Paramore,https://github.com/iancooper/Paramore
-Playscii,http://vectorpoem.com/playscii
-pmap,https://github.com/bruceadams/pmap
-PyBBIO,https://github.com/graycatlabs/PyBBIO
-ROM,https://github.com/rom-rb/rom
-ruby-community,https://github.com/apeiros/ruby-community
-RVM,https://github.com/rvm/rvm
-Snuffle,https://gitlab.com/coraline/snuffle/tree/master
-Snipe-IT,https://github.com/snipe/snipe-it
-vim cheat sheet,https://github.com/rtorr/vim-cheat-sheet
-Volt.rb,https://github.com/voltrb/volt
-WAI-request-spec,https://gitlab.com/cpp.cabrera/wai-request-spec
-xoreos,https://github.com/xoreos/xoreos
+Project Name, Project Link, Code of Conduct
+24 Pull Requests,https://github.com/24pullrequests/24pullrequests,https://github.com/24pullrequests/24pullrequests/blob/master/CODE_OF_CONDUCT.md
+AASM,https://github.com/aasm/aasm,https://github.com/aasm/aasm/blob/master/CODE_OF_CONDUCT.md
+Algorrent,https://github.com/algorrent/algorrent,https://github.com/algorrent/algorrent/blob/master/CODE_OF_CONDUCT.md
+All HaskellNow.org Projects,http://www.haskellnow.org/,http://www.haskellnow.org/wiki/WikiStart#Projects
+AngularJS,https://angularjs.org/,https://github.com/angular/code-of-conduct
+Bundler,https://github.com/bundler/bundler,https://github.com/bundler/bundler/blob/master/CODE_OF_CONDUCT.md
+chef-rvm,https://github.com/fnichol/chef-rvm,https://github.com/martinisoft/chef-rvm/blob/master/CODE_OF_CONDUCT.md
+CloudI,http://cloudi.org/,http://cloudi.org/faq.html#2_CodeOfConduct
+CocoaPods,https://github.com/cocoapods/cocoapods,https://github.com/CocoaPods/CocoaPods/blob/master/CODE_OF_CONDUCT.md
+Crackle,https://github.com/jordanekay/Crackle,https://github.com/jordanekay/Crackle/blob/master/contributor_code_of_conduct.md
+Eldest Daughter Questionnaire,https://github.com/eldest-daughter/ed-questionnaire,https://github.com/eldest-daughter/ed-questionnaire/blob/master/CODE_OF_CONDUCT.md
+Exercism.io,https://github.com/exercism/exercism.io,https://github.com/exercism/exercism.io/blob/master/CODE_OF_CONDUCT.md
+Fukuzatsu,https://gitlab.com/coraline/fukuzatsu/tree/master,https://gitlab.com/coraline/fukuzatsu/blob/master/CODE_OF_CONDUCT.md
+GitLab,https://github.com/gitlabhq/gitlabhq,https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CONTRIBUTING.md
+Growing Devs,https://github.com/growingdevs/growingdevs.github.io,https://github.com/growingdevs/growingdevs.github.io/blob/master/CODE_OF_CONDUCT.md
+Hacken.in,https://github.com/hacken-in/website,https://github.com/hacken-in/website/blob/master/CODE_OF_CONDUCT.md
+Haskell Fill in the Blanks,https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/tree/master,https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/blob/master/CODE_OF_CONDUCT.md
+haxe-pixi,https://github.com/adireddy/haxe-pixi,https://github.com/pixijs/pixi-haxe/blob/master/CODE_OF_CONDUCT.md
+HealingRa.in Projects,https://gitlab.com/groups/healing-rain,https://gitlab.com/healing-rain/prototype/blob/master/CODE_OF_CONDUCT.md
+Homebrew-Cask,https://github.com/caskroom/homebrew-cask,https://github.com/caskroom/homebrew-cask/blob/master/CONDUCT.md
+HTTPotion,https://github.com/myfreeweb/httpotion,https://github.com/myfreeweb/httpotion/blob/master/CODE_OF_CONDUCT.md
+Lotus,http://lotusrb.org/,http://lotusrb.org/community#code-of-conduct
+Mensa,https://github.com/jordanekay/Mensa,https://github.com/jordanekay/Mensa/blob/master/contributor_code_of_conduct.md
+Mozilla Webmaker,https://www.webmaker.org/,https://www.mozilla.org/en-US/about/governance/policies/participation/
+NColony,https://github.com/moshez/ncolony,https://github.com/moshez/ncolony/blob/master/covenant.rst
+OAPI ShieldsUp,https://github.com/oapi/shieldsup,https://github.com/oapi/shieldsup/blob/master/CODE_OF_CONDUCT.md
+OpenDroneMap,https://github.com/OpenDroneMap/OpenDroneMap,https://github.com/OpenDroneMap/OpenDroneMap/blob/gh-pages/code_of_conduct.md
+OpenProject,https://www.openproject.org/,https://github.com/opf/openproject/blob/dev/CODE_OF_CONDUCT.md
+Ornament,https://github.com/jordanekay/Ornament,https://github.com/jordanekay/Ornament/blob/master/contributor_code_of_conduct.md
+Panamax,https://github.com/CenturyLinkLabs/panamax-ui,https://github.com/CenturyLinkLabs/panamax-ui/blob/master/CODE_OF_CONDUCT.md
+Paramore,https://github.com/iancooper/Paramore,https://github.com/iancooper/Paramore/blob/master/CONTRIBUTORS.md
+Playscii,http://vectorpoem.com/playscii,https://bitbucket.org/JPLeBreton/playscii/src/e2fc1f4f120f0f600a2d4291027788e6f6efcad8/code_of_conduct.txt?at=default
+pmap,https://github.com/bruceadams/pmap,https://github.com/bruceadams/pmap/blob/master/CODE_OF_CONDUCT.md
+PyBBIO,https://github.com/graycatlabs/PyBBIO,https://github.com/graycatlabs/PyBBIO/blob/master/CODE_OF_CONDUCT.md
+ROM,https://github.com/rom-rb/rom,https://github.com/rom-rb/rom/blob/master/CODE_OF_CONDUCT.md
+ruby-community,https://github.com/apeiros/ruby-community,https://github.com/apeiros/ruby-community#contributor-code-of-conduct
+RVM,https://github.com/rvm/rvm,https://github.com/rvm/rvm/blob/master/CODE_OF_CONDUCT.md
+Snuffle,https://gitlab.com/coraline/snuffle/tree/master,https://gitlab.com/coraline/snuffle/blob/master/CODE_OF_CONDUCT.md
+Snipe-IT,https://github.com/snipe/snipe-it,https://github.com/snipe/snipe-it/blob/develop/CODE_OF_CONDUCT.md
+vim cheat sheet,https://github.com/rtorr/vim-cheat-sheet,https://github.com/rtorr/vim-cheat-sheet#contributor-code-of-conduct
+Volt.rb,https://github.com/voltrb/volt,https://github.com/voltrb/volt/blob/master/CODE_OF_CONDUCT.md
+WAI-request-spec,https://gitlab.com/cpp.cabrera/wai-request-spec,https://gitlab.com/cpp.cabrera/wai-request-spec/blob/master/CODE_OF_CONDUCT.md
+xoreos,https://github.com/xoreos/xoreos,https://github.com/xoreos/xoreos/blob/master/CODE_OF_CONDUCT.md
+OpenFarm,http://openfarm.cc/,https://openfarm.cc/pages/code_of_conduct?locale=en


### PR DESCRIPTION
# What's Changed
- Added a `.csv` file that contains projects from the contributor covenant. These can be imported at a later point, and people can continue to add to this list through PRs while the project is in maintenance.
- Added **pycache** to gitignore. 

To do with #1. 
