### PR TITLE
Add django-vanilla-views to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ django-braces==1.8.0
 django-extensions==1.5.5
 django-reversion==1.8.7
 django-taggit==0.15.0
+django-vanilla-views==1.0.4
 factory-boy==2.5.2
+greenlet==0.4.7
 oauthlib==0.7.2
 python-dotenv==0.1.2
 python3-openid==3.0.5


### PR DESCRIPTION
# What's Changed
- Noticed that `pip install -r requirements.txt` wasn't installing vanilla, so just installed it and did `pip freeze > requirements.txt`. This PR is the result of that.
