### PR TITLE
Close #8. Add error message to form styling.

### DIFF
--- a/codeofconductlink/settings.py
+++ b/codeofconductlink/settings.py
@@ -92,6 +92,7 @@ TEMPLATES = [
 ]
 
 CRISPY_TEMPLATE_PACK = 'uni_form'
+CRISPY_ALLOWED_TEMPLATE_PACKS = ('uni_form')
 
 WSGI_APPLICATION = 'codeofconductlink.wsgi.application'
 

--- a/profiles/templates/profiles/profile_detail.html
+++ b/profiles/templates/profiles/profile_detail.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% load crispy_forms_tags %}
-{% block rowwrapper %}pure-u-1 pure-u-md-1-2{% endblock %}
+{% block rowwrapper %}pure-u-1 pure-u-md-1-2 center{% endblock %}
 {% block content %}
 <p>Hi {{ user  }}!<br />Your publicly displayed name is <span class="backed">{{ user.name }}</span>.</p>
 

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -26,7 +26,9 @@ class UpdateProjectForm(create_crispy_model_form(
         model = Project
         fields = ('name', 'homepage', 'code_of_conduct', 'tags',)
 
+
 class CreateSubmissionForm(models.ModelForm):
+
     class Meta:
         model = Submission
         fields = ('url', 'tags', 'is_contributor', 'public_message', 'private_message',)

--- a/projects/templates/projects/project_form.html
+++ b/projects/templates/projects/project_form.html
@@ -2,7 +2,7 @@
 
 {% load crispy_forms_tags %}
 
-{% block rowwrapper %}pure-u-1 pure-u-md-1-3{% endblock %}
+{% block rowwrapper %}pure-u-1 pure-u-md-1-3 center{% endblock %}
 {% block content %}
 {% crispy form %}
 {% endblock %}

--- a/static/styles/global.scss
+++ b/static/styles/global.scss
@@ -57,6 +57,7 @@ body {
 
 .center {
     margin: 0 auto;
+    display: block;
 }
 
 p {
@@ -66,7 +67,6 @@ p {
 .clear {
     clear: both;
 }
-
 
 .content-wrapper .pure-g {
     padding: 0.5em 2em;

--- a/static/styles/global.scss
+++ b/static/styles/global.scss
@@ -68,7 +68,7 @@ p {
 }
 
 
-.pure-g {
+.content-wrapper .pure-g {
     padding: 0.5em 2em;
 }
 

--- a/static/styles/global.scss
+++ b/static/styles/global.scss
@@ -23,6 +23,7 @@ $black: #333;
 
 $bg: $midnight-blue;
 $accent: $concrete;
+$error: $alizarin;
 
 $font-stack: 'Open Sans', sans-serif;
 
@@ -66,22 +67,13 @@ p {
     clear: both;
 }
 
-// This is a bit too specific and can probably be refactored:
-.content-wrapper {
-    .pure-g {
-        padding: 0.5em 2em;
 
-        form {
-            input[type="text"], input[type="email"], input[type="password"], input[type="url"] {
-                width: 80%;
-            }
+.pure-g {
+    padding: 0.5em 2em;
+}
 
-            input[type="submit"] {
-            }
-        }
-
-        .box {
-            margin: 0 1em;
-        }
-    }
+// This class name is a bit too generic and meaningless and can
+// probably be refactored
+.box {
+    margin: 0 1em;
 }

--- a/static/styles/ui/forms.scss
+++ b/static/styles/ui/forms.scss
@@ -1,4 +1,10 @@
 form {
+    input[type="text"], input[type="email"], input[type="password"], input[type="url"] {
+        width: 80%;
+    }
+}
+
+form {
     .formHint {
         max-width: 30em;
         margin-left: 1em;
@@ -19,3 +25,31 @@ form {
         margin-bottom: 1em;
     }
 }
+
+.field-wrapper,
+.ctrlHolder {
+    p {
+        margin-bottom: 0;
+    }
+
+    .errorlist {
+        list-style: none;
+        padding: .2em .5em;
+        background: $alizarin;
+        width: 77%;
+        margin: -7px 0 0;
+        color: white;
+    }
+
+    [for=id_remember] {
+        margin-bottom: 1em;
+        display: inline-block;
+    }
+}
+
+.ctrlHolder {
+    .errorlist {
+        width: 76%;
+    }
+}
+

--- a/static/styles/ui/messages.scss
+++ b/static/styles/ui/messages.scss
@@ -11,7 +11,7 @@
         background: $emerald;
     }
     &.error {
-        background: $alizarin;
+        background: $error;
     }
     .close-button {
         visibility: hidden;

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -9,7 +9,11 @@
             {% csrf_token %}
             <fieldset>
                 <legend>Login</legend>
-                {{ form.as_p }}
+                {% for field in form %}
+                    <div class="field-wrapper">
+                        <p>{{ field.label_tag }} {{ field }}</p>{{ field.errors }}
+                    </div>
+                {% endfor %}
                 {% if redirect_field_value %}
                 <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
                 {% endif %}

--- a/templates/uni_form/field.html
+++ b/templates/uni_form/field.html
@@ -4,13 +4,6 @@
     {{ field }}
 {% else %}
     <div id="div_{{ field.auto_id }}" class="ctrlHolder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-        {% if form_show_errors %}
-            {% for error in field.errors %}
-                <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="errorField">
-                    {{ error }}
-                </p>
-            {% endfor %}
-        {% endif %}
 
         {% if field.label %}
             <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
@@ -24,6 +17,17 @@
 
         {% if not field|is_checkbox %}
             {% crispy_field field %}
+        {% endif %}
+        {% if form_show_errors %}
+            {% if field.errors %}
+                <ul class="errorlist">
+                {% for error in field.errors %}
+                    <li id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="errorField">
+                        {{ error }}
+                    </li>
+                {% endfor %}
+            {% endif %}
+            </ul>
         {% endif %}
 
         {% if field.help_text %}


### PR DESCRIPTION
I had to come to grips with crispy forms, so there might be some issues there. Basic styling of error messages, on both log in and on any form that uses crispy forms.
# What's Changed
- Added `uni_form` to the Allowed Template Packs
- Created a variable shortcut to alizarin so that all errors use the same colour.
- Cleaned up some more CSS that was getting a bit too specific maybe?
- Added error styling.
- Restructured forms for log in and in uni_form to have the error appear underneath the input field: 

![screenshot 2015-06-29 16 13 00](https://cloud.githubusercontent.com/assets/485583/8421393/495f0366-1e7a-11e5-9a8e-313f9c830786.png)
